### PR TITLE
feat(core): support permalink: null in frontmatter to disable permalink

### DIFF
--- a/packages/core/src/page/resolvePagePermalink.ts
+++ b/packages/core/src/page/resolvePagePermalink.ts
@@ -25,9 +25,15 @@ export const resolvePagePermalink = ({
     return frontmatter.permalink
   }
 
+  if (frontmatter.permalink === null || frontmatter.permalinkPattern === null) {
+    return null
+  }
+
   // get permalink pattern
-  const permalinkPattern = getPermalinkPattern({ app, frontmatter })
-  if (permalinkPattern === null) {
+  const permalinkPattern =
+    frontmatter.permalinkPattern || app.options.permalinkPattern
+
+  if (!permalinkPattern) {
     return null
   }
 
@@ -44,23 +50,4 @@ export const resolvePagePermalink = ({
   )
 
   return ensureLeadingSlash(link)
-}
-
-/**
- * Get permalink pattern from frontmatter or app options
- */
-const getPermalinkPattern = ({
-  app,
-  frontmatter,
-}: {
-  app: App
-  frontmatter: PageFrontmatter
-}): string | null => {
-  if (frontmatter.permalinkPattern === null) {
-    return null
-  }
-  if (isString(frontmatter.permalinkPattern)) {
-    return frontmatter.permalinkPattern
-  }
-  return app.options.permalinkPattern
 }

--- a/packages/core/src/page/resolvePagePermalink.ts
+++ b/packages/core/src/page/resolvePagePermalink.ts
@@ -20,20 +20,23 @@ export const resolvePagePermalink = ({
   pathInferred: string | null
   pathLocale: string
 }): string | null => {
-  // use permalink in frontmatter directly
+  // frontmatter.permalink has the highest priority
+  if (frontmatter.permalink === null) {
+    return null
+  }
   if (isString(frontmatter.permalink)) {
     return frontmatter.permalink
   }
 
-  if (frontmatter.permalink === null || frontmatter.permalinkPattern === null) {
+  // frontmatter.permalinkPattern has higher priority than app.options.permalinkPattern
+  if (frontmatter.permalinkPattern === null) {
     return null
   }
 
-  // get permalink pattern
   const permalinkPattern =
     frontmatter.permalinkPattern || app.options.permalinkPattern
 
-  if (!permalinkPattern) {
+  if (!isString(permalinkPattern)) {
     return null
   }
 

--- a/packages/core/tests/page/resolvePagePermalink.spec.ts
+++ b/packages/core/tests/page/resolvePagePermalink.spec.ts
@@ -36,6 +36,21 @@ describe('core > page > resolvePagePermalink', () => {
       expect(resolved).toBe('/frontmatter')
     })
 
+    it('should return null', () => {
+      const resolved = resolvePagePermalink({
+        app: appWithPermalinkPattern,
+        frontmatter: {
+          permalink: null,
+        },
+        slug: '',
+        date: '',
+        pathInferred: '/inferred',
+        pathLocale: '',
+      })
+
+      expect(resolved).toBe(null)
+    })
+
     it('should use permalinkPattern in frontmatter', () => {
       const resolved = resolvePagePermalink({
         app,

--- a/packages/shared/src/types/page.ts
+++ b/packages/shared/src/types/page.ts
@@ -62,7 +62,7 @@ export type PageFrontmatter<
   head?: HeadConfig[]
   lang?: string
   layout?: string
-  permalink?: string
+  permalink?: string | null
   permalinkPattern?: string | null
   routeMeta?: Record<string, unknown>
   title?: string


### PR DESCRIPTION
Now users can set permalink: null to disable global `permalinkPattern` affect on certain pages.

This is more natural then setting permalink or permalinkPattern to page path in frontmatter.