### PR TITLE
feat(core): improve loading config file

### DIFF
--- a/packages/cli/src/config/loadUserConfig.ts
+++ b/packages/cli/src/config/loadUserConfig.ts
@@ -18,7 +18,7 @@ export const loadUserConfig = async (
       userConfigDependencies: [],
     }
   }
-  // following code is forked and modified from vite
+  // forked and modified from https://github.com/vitejs/vite/blob/889bfc0ada6d6cd356bb7a92efdce96298f82fef/packages/vite/src/node/config.ts#L1531
   // TODO: we can migrate to something like `bundler-require`, but its `__dirname` support is not as good as vite
   const dirnameVarName = '__vite_injected_original_dirname'
   const filenameVarName = '__vite_injected_original_filename'
@@ -26,18 +26,20 @@ export const loadUserConfig = async (
   const result = await build({
     absWorkingDir: process.cwd(),
     entryPoints: [userConfigPath],
-    outfile: 'out.js',
     write: false,
-    target: ['node18'],
+    target: [`node${process.versions.node}`],
     platform: 'node',
     bundle: true,
     format: 'esm',
+    mainFields: ['main'],
     sourcemap: 'inline',
     metafile: true,
     define: {
       '__dirname': dirnameVarName,
       '__filename': filenameVarName,
       'import.meta.url': importMetaUrlVarName,
+      'import.meta.dirname': dirnameVarName,
+      'import.meta.filename': filenameVarName,
     },
     plugins: [
       {
@@ -58,7 +60,7 @@ export const loadUserConfig = async (
         name: 'inject-file-scope-variables',
         setup(pluginBuild) {
           pluginBuild.onLoad({ filter: /\.[cm]?[jt]s$/ }, async (args) => {
-            const contents = await fs.readFile(args.path, 'utf8')
+            const contents = await fs.readFile(args.path, 'utf-8')
             const injectValues =
               `const ${dirnameVarName} = ${JSON.stringify(
                 path.dirname(args.path),


### PR DESCRIPTION
This improves esbuild config:

1. bundle to correct node version to improve performance
2. add support for `import.meta.dirname` and `import.meta.filename` that is avaibable in node21+