### PR TITLE
fix(bundler-webpack): improve default value for module.noParse

### DIFF
--- a/packages/bundler-webpack/src/config/handleModule.ts
+++ b/packages/bundler-webpack/src/config/handleModule.ts
@@ -26,10 +26,7 @@ export const handleModule = ({
   isServer: boolean
 }): void => {
   // noParse
-  config.module.noParse(
-    /(^(vue|vue-router|vuex|vuex-router-sync)$)|(^@vue\/[^/]*$)/,
-  )
-
+  config.module.noParse(/^(?:vue|vue-router|(?:@vue\/[^/]+))$/)
   // vue files
   handleModuleVue({ app, options, config, isBuild, isServer })
 


### PR DESCRIPTION
vuex is deprecated and the latest version is in 2021, people will prefer pinia if they want a state manager, but normally a docuementaion site do not need complex state managing.