### PR TITLE
test(e2e): update tests for router and route-link

### DIFF
--- a/e2e/docs/components/route-link.md
+++ b/e2e/docs/components/route-link.md
@@ -60,26 +60,26 @@
 - <RouteLink to="/"><span>text</span></RouteLink>
 - <RouteLink to="/"><span>text</span><span>text2</span></RouteLink>
 
-### Hash and query
+### Query and hash
 
 - <RouteLink to="/README.md#hash">text</RouteLink>
+- <RouteLink to="/README.md#/id?a=1&b=2">text</RouteLink>
 - <RouteLink to="/README.md?query">text</RouteLink>
 - <RouteLink to="/README.md?query#hash">text</RouteLink>
 - <RouteLink to="/README.md?query=1#hash">text</RouteLink>
 - <RouteLink to="/README.md?query=1&query=2#hash">text</RouteLink>
-- <RouteLink to="/README.md#hash?query=1&query=2">text</RouteLink>
 - <RouteLink to="/#hash">text</RouteLink>
+- <RouteLink to="/#/id?a=1&b=2">text</RouteLink>
 - <RouteLink to="/?query">text</RouteLink>
 - <RouteLink to="/?query#hash">text</RouteLink>
 - <RouteLink to="/?query=1#hash">text</RouteLink>
 - <RouteLink to="/?query=1&query=2#hash">text</RouteLink>
-- <RouteLink to="/#hash?query=1&query=2">text</RouteLink>
 - <RouteLink to="#hash">text</RouteLink>
+- <RouteLink to="#/id?a=1&b=2">text</RouteLink>
 - <RouteLink to="?query">text</RouteLink>
 - <RouteLink to="?query#hash">text</RouteLink>
 - <RouteLink to="?query=1#hash">text</RouteLink>
 - <RouteLink to="?query=1&query=2#hash">text</RouteLink>
-- <RouteLink to="#hash?query=1&query=2">text</RouteLink>
 
 ### Relative
 

--- a/e2e/docs/router/navigate-by-link.md
+++ b/e2e/docs/router/navigate-by-link.md
@@ -5,7 +5,7 @@
 - [Home with query](/README.md?home=true)
 - [Home with query and hash](/README.md?home=true#home)
 - [404 with hash](/404.md#404)
-- [404 with hash and query](/404.md#404?notFound=true)
+- [404 with complex hash](/404.md#/404?lang=en)
 
 ## HTML Links
 
@@ -23,6 +23,6 @@
 - [Home with query](/?home=true)
 - [Home with query and hash](/?home=true#home)
 - [404 with hash](/404.html#404)
-- [404 with hash and query](/404.html#404?notFound=true)
+- [404 with complex hash](/404.html#/404?lang=en)
 
 > Non-recommended usage. HTML paths could not be prepended with `base` correctly.

--- a/e2e/docs/router/navigate-by-router.md
+++ b/e2e/docs/router/navigate-by-router.md
@@ -4,7 +4,7 @@
 <button id="home-with-query" @click="goHomeWithQuery">Home</button>
 <button id="home-with-query-and-hash" @click="goHomeWithQueryAndHash">Home</button>
 <button id="not-found-with-hash" @click="go404WithHash">404</button>
-<button id="not-found-with-complex-hash" @click="go404WithQueryAndHash">404</button>
+<button id="not-found-with-complex-hash" @click="go404WithComplexHash">404</button>
 
 <script setup lang="ts">
 import { useRouter } from 'vuepress/client';
@@ -31,7 +31,7 @@ const go404WithHash = () => {
   router.push('/404.html#_404');
 }
 
-const go404WithQueryAndHash = () => {
+const go404WithComplexHash = () => {
   router.push('/404.html#/404?lang=en');
 }
 </script>

--- a/e2e/docs/router/navigate-by-router.md
+++ b/e2e/docs/router/navigate-by-router.md
@@ -4,7 +4,7 @@
 <button id="home-with-query" @click="goHomeWithQuery">Home</button>
 <button id="home-with-query-and-hash" @click="goHomeWithQueryAndHash">Home</button>
 <button id="not-found-with-hash" @click="go404WithHash">404</button>
-<button id="not-found-with-hash-and-query" @click="go404WithHashAndQuery">404</button>
+<button id="not-found-with-complex-hash" @click="go404WithQueryAndHash">404</button>
 
 <script setup lang="ts">
 import { useRouter } from 'vuepress/client';
@@ -31,7 +31,7 @@ const go404WithHash = () => {
   router.push('/404.html#_404');
 }
 
-const go404WithHashAndQuery = () => {
-  router.push('/404.html#_404?notFound=true');
+const go404WithQueryAndHash = () => {
+  router.push('/404.html#/404?lang=en');
 }
 </script>

--- a/e2e/tests/components/route-link.spec.ts
+++ b/e2e/tests/components/route-link.spec.ts
@@ -143,31 +143,31 @@ test('should render slots correctly', async ({ page }) => {
   }
 })
 
-test('should render hash and query correctly', async ({ page }) => {
+test('should render query and hash correctly', async ({ page }) => {
   const CONFIGS = [
     `${BASE}#hash`,
+    `${BASE}#/id?a=1&b=2`,
     `${BASE}?query`,
     `${BASE}?query#hash`,
     `${BASE}?query=1#hash`,
     `${BASE}?query=1&query=2#hash`,
-    `${BASE}#hash?query=1&query=2`,
     `${BASE}#hash`,
+    `${BASE}#/id?a=1&b=2`,
     `${BASE}?query`,
     `${BASE}?query#hash`,
     `${BASE}?query=1#hash`,
     `${BASE}?query=1&query=2#hash`,
-    `${BASE}#hash?query=1&query=2`,
     `#hash`,
+    `#/id?a=1&b=2`,
     `?query`,
     `?query#hash`,
     `?query=1#hash`,
     `?query=1&query=2#hash`,
-    `#hash?query=1&query=2`,
   ]
 
   for (const [index, href] of CONFIGS.entries()) {
     await expect(
-      page.locator('.e2e-theme-content #hash-and-query + ul > li a').nth(index),
+      page.locator('.e2e-theme-content #query-and-hash + ul > li a').nth(index),
     ).toHaveAttribute('href', href)
   }
 })

--- a/e2e/tests/router/navigate-by-link.spec.ts
+++ b/e2e/tests/router/navigate-by-link.spec.ts
@@ -7,64 +7,68 @@ test.beforeEach(async ({ page }) => {
 })
 
 test.describe('markdown links', () => {
+  const selector = '#markdown-links + ul > li > a'
+
   test('should navigate to home correctly', async ({ page }) => {
-    await page.locator('#markdown-links + ul > li > a').nth(0).click()
+    await page.locator(selector).nth(0).click()
     await expect(page).toHaveURL(BASE)
     await expect(page.locator('#home-h2')).toHaveText('Home H2')
   })
 
   test('should navigate to 404 page correctly', async ({ page }) => {
-    await page.locator('#markdown-links + ul > li > a').nth(1).click()
+    await page.locator(selector).nth(1).click()
     await expect(page).toHaveURL(`${BASE}404.html`)
     await expect(page.locator('#notfound-h2')).toHaveText('NotFound H2')
   })
 
   test('should preserve query', async ({ page }) => {
-    await page.locator('#markdown-links + ul > li > a').nth(2).click()
+    await page.locator(selector).nth(2).click()
     await expect(page).toHaveURL(`${BASE}?home=true`)
     await expect(page.locator('#home-h2')).toHaveText('Home H2')
   })
 
   test('should preserve query and hash', async ({ page }) => {
-    await page.locator('#markdown-links + ul > li > a').nth(3).click()
+    await page.locator(selector).nth(3).click()
     await expect(page).toHaveURL(`${BASE}?home=true#home`)
     await expect(page.locator('#home-h2')).toHaveText('Home H2')
   })
 
   test('should preserve hash', async ({ page }) => {
-    await page.locator('#markdown-links + ul > li > a').nth(4).click()
+    await page.locator(selector).nth(4).click()
     await expect(page).toHaveURL(`${BASE}404.html#_404`)
     await expect(page.locator('#notfound-h2')).toHaveText('NotFound H2')
   })
 
-  test('should preserve hash and query', async ({ page }) => {
-    await page.locator('#markdown-links + ul > li > a').nth(5).click()
-    await expect(page).toHaveURL(`${BASE}404.html#_404?notFound=true`)
+  test('should preserve complex hash', async ({ page }) => {
+    await page.locator(selector).nth(5).click()
+    await expect(page).toHaveURL(`${BASE}404.html#/404?lang=en`)
     await expect(page.locator('#notfound-h2')).toHaveText('NotFound H2')
   })
 })
 
 test.describe('html links', () => {
+  const selector = '#html-links + p > a'
+
   test('should navigate to home correctly', async ({ page }) => {
-    await page.locator('#html-links + p > a').nth(0).click()
+    await page.locator(selector).nth(0).click()
     await expect(page).toHaveURL(BASE)
     await expect(page.locator('#home-h2')).toHaveText('Home H2')
   })
 
   test('should navigate to 404 page correctly', async ({ page }) => {
-    await page.locator('#html-links + p > a').nth(1).click()
+    await page.locator(selector).nth(1).click()
     await expect(page).toHaveURL(`${BASE}404.html`)
     await expect(page.locator('#notfound-h2')).toHaveText('NotFound H2')
   })
 
   test('should preserve query', async ({ page }) => {
-    await page.locator('#html-links + p > a').nth(2).click()
+    await page.locator(selector).nth(2).click()
     await expect(page).toHaveURL(`${BASE}?home=true`)
     await expect(page.locator('#home-h2')).toHaveText('Home H2')
   })
 
   test('should preserve query and hash', async ({ page }) => {
-    await page.locator('#html-links + p > a').nth(3).click()
+    await page.locator(selector).nth(3).click()
     await expect(page).toHaveURL(`${BASE}?home=true#home`)
     await expect(page.locator('#home-h2')).toHaveText('Home H2')
   })
@@ -83,16 +87,82 @@ test.describe('html links', () => {
 })
 
 test.describe('markdown links with html paths', () => {
+  const selector = '#markdown-links-with-html-paths + ul > li > a'
+
   test('should navigate to home correctly', async ({ page }) => {
-    const locator = page
-      .locator('#markdown-links-with-html-paths + ul > li > a')
-      .nth(0)
+    const locator = page.locator(selector).nth(0)
+
     if (BASE === '/') {
       await locator.click()
       await expect(page).toHaveURL('/')
       await expect(page.locator('#home-h2')).toHaveText('Home H2')
     } else {
       await expect(locator).toHaveAttribute('href', '/')
+      await expect(locator).toHaveAttribute('target', '_blank')
+    }
+  })
+
+  test('should navigate to 404 page correctly', async ({ page }) => {
+    const locator = page.locator(selector).nth(1)
+
+    if (BASE === '/') {
+      await locator.click()
+      await expect(page).toHaveURL(`${BASE}404.html`)
+      await expect(page.locator('#notfound-h2')).toHaveText('NotFound H2')
+    } else {
+      await expect(locator).toHaveAttribute('href', '/404.html')
+      await expect(locator).toHaveAttribute('target', '_blank')
+    }
+  })
+
+  test('should preserve query', async ({ page }) => {
+    const locator = page.locator(selector).nth(2)
+
+    if (BASE === '/') {
+      await locator.click()
+      await expect(page).toHaveURL(`${BASE}?home=true`)
+      await expect(page.locator('#home-h2')).toHaveText('Home H2')
+    } else {
+      await expect(locator).toHaveAttribute('href', '/?home=true')
+      await expect(locator).toHaveAttribute('target', '_blank')
+    }
+  })
+
+  test('should preserve query and hash', async ({ page }) => {
+    const locator = page.locator(selector).nth(3)
+
+    if (BASE === '/') {
+      await locator.click()
+      await expect(page).toHaveURL(`${BASE}?home=true#home`)
+      await expect(page.locator('#home-h2')).toHaveText('Home H2')
+    } else {
+      await expect(locator).toHaveAttribute('href', '/?home=true#home')
+      await expect(locator).toHaveAttribute('target', '_blank')
+    }
+  })
+
+  test('should preserve hash', async ({ page }) => {
+    const locator = page.locator(selector).nth(4)
+
+    if (BASE === '/') {
+      await locator.click()
+      await expect(page).toHaveURL(`${BASE}404.html#_404`)
+      await expect(page.locator('#notfound-h2')).toHaveText('NotFound H2')
+    } else {
+      await expect(locator).toHaveAttribute('href', '/404.html#404')
+      await expect(locator).toHaveAttribute('target', '_blank')
+    }
+  })
+
+  test('should preserve complex hash', async ({ page }) => {
+    const locator = page.locator(selector).nth(5)
+
+    if (BASE === '/') {
+      await locator.click()
+      await expect(page).toHaveURL(`${BASE}404.html#/404?lang=en`)
+      await expect(page.locator('#notfound-h2')).toHaveText('NotFound H2')
+    } else {
+      await expect(locator).toHaveAttribute('href', '/404.html#/404?lang=en')
       await expect(locator).toHaveAttribute('target', '_blank')
     }
   })

--- a/e2e/tests/router/navigate-by-router.spec.ts
+++ b/e2e/tests/router/navigate-by-router.spec.ts
@@ -36,8 +36,8 @@ test('should preserve hash', async ({ page }) => {
   await expect(page.locator('#notfound-h2')).toHaveText('NotFound H2')
 })
 
-test('should preserve hash and query', async ({ page }) => {
-  await page.locator('#not-found-with-hash-and-query').click()
-  await expect(page).toHaveURL(`${BASE}404.html#_404?notFound=true`)
+test('should preserve complex hash', async ({ page }) => {
+  await page.locator('#not-found-with-complex-hash').click()
+  await expect(page).toHaveURL(`${BASE}404.html#/404?lang=en`)
   await expect(page.locator('#notfound-h2')).toHaveText('NotFound H2')
 })


### PR DESCRIPTION
Current e2e tests are a bit confusing, as everything behind `#` will be treated as hash, so there won't be any "hash + query" urls.

Now, tests are correctly described as complex hash with updated tests