### PR TITLE
ci: replace compromised issues helper action

### DIFF
--- a/.github/workflows/issue-commented.yml
+++ b/.github/workflows/issue-commented.yml
@@ -4,14 +4,19 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+
 jobs:
   issue-commented:
     name: remove stale on commented
     if: contains(github.event.issue.labels.*.name, 'stale')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'remove-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: 'stale'
+      - name: Remove stale label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh api --method DELETE "repos/${GH_REPO}/issues/${ISSUE_NUMBER}/labels/stale"

--- a/.github/workflows/issue-daily.yml
+++ b/.github/workflows/issue-daily.yml
@@ -12,34 +12,72 @@ jobs:
     name: label stale issues
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'check-inactive'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          inactive-day: 15
-          inactive-label: 'stale'
-          exclude-labels: 'bug, documentation, enhancement, feature, help wanted, need reproduction, need review, stale'
-          body: |
-            This issue is marked as `stale` because it has not had recent activity. Issues marked with `stale` will be closed if they have no activity within 7 days.
+      - name: Label inactive issues as stale
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          cutoff="$(date -u -d '15 days ago' '+%Y-%m-%d')"
+          query="repo:${GH_REPO} is:issue is:open updated:<${cutoff}"
+          excluded_labels=(
+            "bug"
+            "documentation"
+            "enhancement"
+            "feature"
+            "help wanted"
+            "need reproduction"
+            "need review"
+            "stale"
+          )
+
+          for label in "${excluded_labels[@]}"; do
+            query="${query} -label:\"${label}\""
+          done
+
+          printf 'This issue is marked as `stale` because it has not had recent activity. Issues marked with `stale` will be closed if they have no activity within 7 days.\n' > "${RUNNER_TEMP}/stale-comment.md"
+
+          gh api --method GET --paginate /search/issues -f q="${query}" -f per_page=100 --jq '.items[].number' |
+            while read -r issue_number; do
+              gh issue edit "${issue_number}" --repo "${GH_REPO}" --add-label "stale"
+              gh issue comment "${issue_number}" --repo "${GH_REPO}" --body-file "${RUNNER_TEMP}/stale-comment.md"
+            done
 
   issue-close-stale:
     name: close stale issues
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'close-issues'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: 'stale'
-          inactive-day: 7
+      - name: Close inactive stale issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          cutoff="$(date -u -d '7 days ago' '+%Y-%m-%d')"
+          query="repo:${GH_REPO} is:issue is:open label:\"stale\" updated:<${cutoff}"
+
+          gh api --method GET --paginate /search/issues -f q="${query}" -f per_page=100 --jq '.items[].number' |
+            while read -r issue_number; do
+              gh issue close "${issue_number}" --repo "${GH_REPO}"
+            done
 
   issue-close-need-reproduction:
     name: close need-reproduction issues
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'close-issues'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: 'need reproduction'
-          inactive-day: 7
+      - name: Close inactive need-reproduction issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          cutoff="$(date -u -d '7 days ago' '+%Y-%m-%d')"
+          query="repo:${GH_REPO} is:issue is:open label:\"need reproduction\" updated:<${cutoff}"
+
+          gh api --method GET --paginate /search/issues -f q="${query}" -f per_page=100 --jq '.items[].number' |
+            while read -r issue_number; do
+              gh issue close "${issue_number}" --repo "${GH_REPO}"
+            done

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -13,21 +13,30 @@ jobs:
     if: github.event.label.name == 'invalid'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'close-issue, create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
-            Hello @${{ github.event.issue.user.login }}. This issue is marked as `invalid` and closed. Please follow the issue template.
+      - name: Comment and close invalid issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          printf 'Hello @%s. This issue is marked as `invalid` and closed. Please follow the issue template.\n' "${ISSUE_AUTHOR}" > "${RUNNER_TEMP}/invalid-comment.md"
+
+          gh issue comment "${ISSUE_NUMBER}" --repo "${GH_REPO}" --body-file "${RUNNER_TEMP}/invalid-comment.md"
+          gh issue close "${ISSUE_NUMBER}" --repo "${GH_REPO}"
 
   issue-need-reproduction:
     name: need reproduction
     if: github.event.label.name == 'need reproduction'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
-            Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [vuepress.vuejs.org/new](https://vuepress.vuejs.org/new). Issues marked with `need reproduction` will be closed if they have no activity within 7 days.
+      - name: Comment on need reproduction issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          printf 'Hello @%s. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [vuepress.vuejs.org/new](https://vuepress.vuejs.org/new). Issues marked with `need reproduction` will be closed if they have no activity within 7 days.\n' "${ISSUE_AUTHOR}" > "${RUNNER_TEMP}/need-reproduction-comment.md"
+
+          gh issue comment "${ISSUE_NUMBER}" --repo "${GH_REPO}" --body-file "${RUNNER_TEMP}/need-reproduction-comment.md"


### PR DESCRIPTION
Replaces the compromised GH Action (see [source](https://www.stepsecurity.io/blog/actions-cool-issues-helper-github-action-compromised-all-tags-point-to-imposter-commit-that-exfiltrates-ci-cd-credentials)) with a GH script.