### PR TITLE
fix(client): fix client data injection failure caused by HMR (close #1715)

### DIFF
--- a/e2e/docs/hmr/InjectClientData.vue
+++ b/e2e/docs/hmr/InjectClientData.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { useData } from 'vuepress/client'
+
+const { page } = useData()
+</script>
+
+<template>
+  <p>current path: {{ page.path }}</p>
+</template>

--- a/e2e/docs/hmr/inject-client-data.md
+++ b/e2e/docs/hmr/inject-client-data.md
@@ -1,0 +1,11 @@
+# Inject ClientData
+
+<script setup lang="ts">
+import InjectClientData from './InjectClientData.vue'
+</script>
+
+<InjectClientData />
+
+## content
+
+Current Content

--- a/e2e/tests/hmr-inject-client-data.spec.ts
+++ b/e2e/tests/hmr-inject-client-data.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test'
+
+import { IS_DEV } from '../utils/env'
+import { readSourceMarkdown, writeSourceMarkdown } from '../utils/source'
+
+const updateContent = async (): Promise<void> => {
+  const markdownContent = await readSourceMarkdown('hmr/inject-client-data.md')
+  await writeSourceMarkdown(
+    'hmr/inject-client-data.md',
+    markdownContent.replace('Current Content', 'Updated Content'),
+  )
+}
+
+const restoreContent = async (): Promise<void> => {
+  const markdownContent = await readSourceMarkdown('hmr/inject-client-data.md')
+  await writeSourceMarkdown(
+    'hmr/inject-client-data.md',
+    markdownContent.replace('Updated Content', 'Current Content'),
+  )
+}
+
+if (IS_DEV) {
+  test.beforeEach(async () => {
+    await restoreContent()
+  })
+  test.afterAll(async () => {
+    await restoreContent()
+  })
+
+  test('should update content when include component (inject client data)', async ({
+    page,
+  }) => {
+    await page.goto('hmr/inject-client-data.html')
+    const contentLocator = page.locator('.e2e-theme-content #content + p')
+
+    await expect(contentLocator).toHaveText('Current Content')
+    await updateContent()
+    await expect(contentLocator).toHaveText('Updated Content')
+  })
+}

--- a/packages/client/src/composables/clientData.ts
+++ b/packages/client/src/composables/clientData.ts
@@ -3,12 +3,37 @@ import { inject } from 'vue'
 
 import type { ClientData } from '../types/index.js'
 
+const CLIENT_DATA_SYMBOL_GLOBAL_KEY = '__VUEPRESS_CLIENT_DATA_SYMBOL__'
+
 /**
  * Injection key for client data
+ *
+ * Use a global Symbol to keep the same reference across module reloads.
+ * This is required for HMR in dev mode: when a markdown page with local
+ * components is edited, the main module (and its transitive deps that host
+ * this symbol) may be re-executed by Vite, which would otherwise create a
+ * new Symbol instance and break `inject` (see vuepress/core#1715).
  */
-export const clientDataSymbol: InjectionKey<ClientData> = Symbol(
-  __VUEPRESS_DEV__ ? 'clientData' : '',
-)
+const resolveClientDataSymbol = (): InjectionKey<ClientData> => {
+  const existing = globalThis[
+    CLIENT_DATA_SYMBOL_GLOBAL_KEY
+  ] as InjectionKey<ClientData> | null
+
+  if (existing) return existing
+
+  const symbol: InjectionKey<ClientData> = Symbol('clientData')
+  globalThis[CLIENT_DATA_SYMBOL_GLOBAL_KEY] = symbol
+  return symbol
+}
+
+/**
+ * The problem only occurs during hot updates in the development environment,
+ * It only needs to be processed in the development environment.
+ * (see vuepress/core#1715)
+ */
+export const clientDataSymbol: InjectionKey<ClientData> = __VUEPRESS_DEV__
+  ? resolveClientDataSymbol()
+  : Symbol('')
 
 /**
  * Returns client data

--- a/packages/client/src/composables/clientData.ts
+++ b/packages/client/src/composables/clientData.ts
@@ -15,15 +15,8 @@ const CLIENT_DATA_SYMBOL_GLOBAL_KEY = '__VUEPRESS_CLIENT_DATA_SYMBOL__'
  * new Symbol instance and break `inject` (see vuepress/core#1715).
  */
 const resolveClientDataSymbol = (): InjectionKey<ClientData> => {
-  const existing = globalThis[
-    CLIENT_DATA_SYMBOL_GLOBAL_KEY
-  ] as InjectionKey<ClientData> | null
-
-  if (existing) return existing
-
-  const symbol: InjectionKey<ClientData> = Symbol('clientData')
-  globalThis[CLIENT_DATA_SYMBOL_GLOBAL_KEY] = symbol
-  return symbol
+  globalThis[CLIENT_DATA_SYMBOL_GLOBAL_KEY] ??= Symbol('clientData')
+  return globalThis[CLIENT_DATA_SYMBOL_GLOBAL_KEY] as InjectionKey<ClientData>
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/vuepress/core/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

### Description

resolve #1715.

From a shallow analysis, this is a bug caused by the module-level constant `symbol('clientData')` being replaced with a new constant during hot updates.  

This PR can fix the issue.

However, the deeper reason is that every time markdown is updated, two `import.meta.hot.accept` callbacks are triggered. In these callbacks, the component chunk returns a new object (a new component) each time, and one is asynchronous while the other is synchronous:

1. Vue plugin callback: executes `reload` or `rerender`
2. Vuepress callback: executes `updatePageData`

Internally, there is a race condition rewriting of the hot-updated components between these two, and the problem may have started from this point.

Regarding the hot-update issue from markdown to Vue, I believe it is necessary to rewrite it appropriately to fundamentally solve such problems.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Screenshots

<!-- If your PR includes UI changes, please provide before/after screenshots. If there are any other images that add context to the PR, add them here as well -->

**Before**

**After**
